### PR TITLE
Added stopAnimation method. It fixes memory release problem.

### DIFF
--- a/KenBurns/JBKenBurnsView.h
+++ b/KenBurns/JBKenBurnsView.h
@@ -41,6 +41,7 @@
 
 - (void) animateWithImagePaths:(NSArray *)imagePaths transitionDuration:(float)time loop:(BOOL)isLoop isLandscape:(BOOL)isLandscape;
 - (void) animateWithImages:(NSArray *)images transitionDuration:(float)time loop:(BOOL)isLoop isLandscape:(BOOL)isLandscape;
+- (void) stopAnimation;
 @end
 
 

--- a/KenBurns/JBKenBurnsView.m
+++ b/KenBurns/JBKenBurnsView.m
@@ -84,6 +84,13 @@ enum JBSourceMode {
     [self _startAnimationsWithData:images transitionDuration:duration loop:shouldLoop isLandscape:isLandscape];
 }
 
+- (void)stopAnimation {
+    if (_nextImageTimer && [_nextImageTimer isValid]) {
+        [_nextImageTimer invalidate];
+        _nextImageTimer = nil;
+    }
+}
+
 - (void)_startAnimationsWithData:(NSArray *)data transitionDuration:(float)duration loop:(BOOL)shouldLoop isLandscape:(BOOL)isLandscape
 {
     _imagesArray        = [data mutableCopy];


### PR DESCRIPTION
This new method should be called whenever we want to release the instance of JBKenBurns.
It fixes memory release problem when instance is not deallocated and animation continued to play.
