### PR TITLE
Support for configuring the zoom direction of the animation.

### DIFF
--- a/KenBurns/JBKenBurnsView.h
+++ b/KenBurns/JBKenBurnsView.h
@@ -36,11 +36,18 @@
 @end
 
 
+NS_ENUM(NSInteger, JBZoomMode) {
+    JBZoomModeIn,
+    JBZoomModeOut,
+    JBZoomModeRandom
+};
+
 
 @interface JBKenBurnsView : UIView
 
 @property (nonatomic,weak) id<KenBurnsViewDelegate> delegate;
 @property (nonatomic,assign,readonly) NSInteger currentImageIndex;
+@property (nonatomic,assign) enum JBZoomMode zoomMode;
 
 ///----------------------------------
 /// @name Initialization


### PR DESCRIPTION
The default implementation of the JBKenBurnsView always zooms in on images. This adds support for allowing the user to choose the direction of zoom: in, out, or a random direction.