### PR TITLE
Fix Photos that doesn't fill the view

### DIFF
--- a/KenBurns/JBKenBurnsView.m
+++ b/KenBurns/JBKenBurnsView.m
@@ -324,7 +324,7 @@ enum JBSourceMode {
         {
             heightDiff = frameHeight - image.size.height;
             
-            if (widthDiff > heightDiff)
+            if (widthDiff < heightDiff)
                 resizeRatio = frameWidth / image.size.width;
             else
                 resizeRatio = self.bounds.size.height / image.size.height;
@@ -350,7 +350,7 @@ enum JBSourceMode {
         {
             heightDiff = frameHeight - image.size.height;
             
-            if (widthDiff > heightDiff)
+            if (widthDiff < heightDiff)
                 resizeRatio = frameWidth / image.size.width;
             else
                 resizeRatio = frameHeight / image.size.height;


### PR DESCRIPTION
#35  Photos with lower-res doesn't fill view on iPhone 6 Plus