### PR TITLE
Fix missing call to super on awakeFromNib

### DIFF
--- a/KenBurns/JBKenBurnsView.h
+++ b/KenBurns/JBKenBurnsView.h
@@ -35,19 +35,18 @@
 
 @end
 
-
-NS_ENUM(NSInteger, JBZoomMode) {
+typedef enum {
     JBZoomModeIn,
     JBZoomModeOut,
     JBZoomModeRandom
-};
+} JBZoomMode;
 
 
 @interface JBKenBurnsView : UIView
 
 @property (nonatomic,weak) id<KenBurnsViewDelegate> delegate;
 @property (nonatomic,assign,readonly) NSInteger currentImageIndex;
-@property (nonatomic,assign) enum JBZoomMode zoomMode;
+@property (nonatomic,assign) JBZoomMode zoomMode;
 
 ///----------------------------------
 /// @name Initialization

--- a/KenBurns/JBKenBurnsView.m
+++ b/KenBurns/JBKenBurnsView.m
@@ -61,6 +61,7 @@ enum JBSourceMode {
 
 - (void)awakeFromNib
 {
+    [super awakeFromNib];
     [self setup];
 }
 


### PR DESCRIPTION
Fix missing call to super on awakeFromNib method and declare JBZoomMode explicitly as a typedef enum.