### PR TITLE
Fix compiler warning, update podspec version to 1.0.1

### DIFF
--- a/JBKenBurnsView.podspec
+++ b/JBKenBurnsView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'JBKenBurnsView'
-  s.version  = '1.0'
+  s.version  = '1.0.1'
   s.license  = { :type => 'MIT', :file => 'LICENSE' }
   s.summary  = 'UIView that can generate a Ken Burns transition when given an array of images or paths.'
   s.framework = 'QuartzCore'

--- a/KenBurns/JBKenBurnsView.h
+++ b/KenBurns/JBKenBurnsView.h
@@ -68,7 +68,7 @@ typedef enum {
 
 /**
  Start the animation with a NSArray of UIImages.
- @param imagePaths  A NSArray of images.
+ @param images  A NSArray of images.
  @param time        The number of second of each image.
  @param isLoop      YES if you want to play the animation in loop.
  @param isLandscape YES if the view is in landscape mode.


### PR DESCRIPTION
Fix compiler warning that shows up when using Xcode 8.3 and update podspec version to 1.0.1 for a new release.